### PR TITLE
Use the next attempt at fixing feature resolution in meson

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ mouse button.
 ### meson build
 
 For building the application with [meson](https://mesonbuild.com/), the
-following PRs, that were not merged yet at the time of writing, are needed:
+following PR, that is a draft at the time of writing, is needed:
 
-  * https://github.com/mesonbuild/meson/pull/13780
-  * https://github.com/mesonbuild/meson/pull/14659
-  * https://github.com/mesonbuild/meson/pull/14660
+  * https://github.com/mesonbuild/meson/pull/15069
+
+The PR in turn is a superset of https://github.com/mesonbuild/meson/pull/14906.
 
 ```bash
 # Building
@@ -27,6 +27,8 @@ _builddir/mandelbrot
 # Installing
 ninja -C _builddir install
 ```
+
+Cross compilation is not supported yet.
 
 ### Screenshot
 

--- a/meson.build
+++ b/meson.build
@@ -3,9 +3,6 @@ project('mandelbrot', 'rust',
   meson_version : '>= 1.0.0',
   default_options : ['buildtype=debugoptimized',
                      'rust_std=2018',
-                     # workaround for feature resolution bug
-                     'futures-core-0.3-rs:feature-std=true',
-                     'futures-core-0.3-rs:feature-alloc=true',
                     ]
 )
 
@@ -16,12 +13,18 @@ add_global_arguments(
   language: 'rust'
 )
 
+# the object is not used yet, but it triggers dependency resolution
+# and applies dependency features in Cargo.toml.
+cargo = import('rust').workspace()
+
+# later: cargo.package().executables() replaces everything below
+
 num_complex_dep = dependency('num-complex-0.4-rs')
 rayon_dep = dependency('rayon-1-rs')
 once_cell_dep = dependency('once_cell-1-rs')
 async_channel_dep = dependency('async-channel-2-rs')
 gtk_dep = dependency('gtk4-0.10-rs')
-zerocopy_dep = dependency('zerocopy-0.8-rs', default_options: {'feature-derive': true})
+zerocopy_dep = dependency('zerocopy-0.8-rs')
 
 executable('mandelbrot', 'src/main.rs',
   rust_dependency_map : {


### PR DESCRIPTION
Link the PR that uses a toplevel Cargo.toml to trigger feature resolution for all the dependencies at once, and remove the two PRs that have been merged.

The full design for the Rust workspace functionality is available at mesonbuild/meson#14639; for now only the bare minimum is implemented, and the dependency/executable calls are still manual.