### PR TITLE
Use cargo.package()

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ mouse button.
 
 ### meson build
 
-For building the application with [meson](https://mesonbuild.com/), latest git
-`master` or the upcoming 1.11 release are needed.
+For building the application with [meson](https://mesonbuild.com/), you
+need Meson's latest git `master` or the 1.11 release (not yet ready at
+the time of this writing).
 
 ```bash
 # Building

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('mandelbrot', 'rust',
   version : '0.1.0',
-  meson_version : '>= 1.0.0',
+  meson_version : '>= 1.10.99',
   default_options : ['buildtype=debugoptimized',
                      'rust_std=2018',
                     ]

--- a/meson.build
+++ b/meson.build
@@ -8,9 +8,11 @@ project('mandelbrot', 'rust',
 
 # trigger dependency resolution and apply dependency features in Cargo.toml.
 cargo = import('rust').workspace()
+pkg = cargo.package()
 
-# with the minimal PR https://github.com/mesonbuild/meson/pull/15158,
-# retrieve direct dependencies by hand
+# ultimately this becomes just:
+#   cargo.package().executable('mandelbrot', install: true)
+# for demonstration purposes, retrieve direct dependencies by hand
 num_complex_dep = cargo.subproject('num-complex').dependency()
 rayon_dep = cargo.subproject('rayon').dependency()
 once_cell_dep = cargo.subproject('once_cell').dependency()
@@ -19,12 +21,8 @@ gtk_dep = cargo.subproject('gtk4').dependency()
 zerocopy_dep = cargo.subproject('zerocopy').dependency()
 
 executable('mandelbrot', 'src/main.rs',
-  rust_dependency_map : {
-    'gtk4' : 'gtk',
-  },
+  rust_dependency_map : pkg.rust_dependency_map(),
+  rust_args: pkg.rust_args(),
   dependencies : [gtk_dep, num_complex_dep, rayon_dep, once_cell_dep, async_channel_dep, zerocopy_dep],
   install : true,
 )
-
-# with the complete PR https://github.com/mesonbuild/meson/pull/15223:
-# cargo.package().executable('mandelbrot', install: true)

--- a/meson.build
+++ b/meson.build
@@ -12,17 +12,10 @@ pkg = cargo.package()
 
 # ultimately this becomes just:
 #   cargo.package().executable('mandelbrot', install: true)
-# for demonstration purposes, retrieve direct dependencies by hand
-num_complex_dep = cargo.subproject('num-complex').dependency()
-rayon_dep = cargo.subproject('rayon').dependency()
-once_cell_dep = cargo.subproject('once_cell').dependency()
-async_channel_dep = cargo.subproject('async-channel').dependency()
-gtk_dep = cargo.subproject('gtk4').dependency()
-zerocopy_dep = cargo.subproject('zerocopy').dependency()
-
+# for demonstration purposes, build arguments to executable() by hand
 executable('mandelbrot', 'src/main.rs',
   rust_dependency_map : pkg.rust_dependency_map(),
   rust_args: pkg.rust_args(),
-  dependencies : [gtk_dep, num_complex_dep, rayon_dep, once_cell_dep, async_channel_dep, zerocopy_dep],
+  dependencies : pkg.dependencies(),
   install : true,
 )

--- a/meson.build
+++ b/meson.build
@@ -1,21 +1,21 @@
 project('mandelbrot', 'rust',
   version : '0.1.0',
   meson_version : '>= 1.10.99',
-  default_options : ['buildtype=debugoptimized',
-                     'rust_std=2018',
-                    ]
+  default_options : ['buildtype=debugoptimized']
 )
 
-# trigger dependency resolution and apply dependency features in Cargo.toml.
 cargo = import('rust').workspace()
-pkg = cargo.package()
+cargo.package().executable(install: true)
 
-# ultimately this becomes just:
-#   cargo.package().executable('mandelbrot', install: true)
-# for demonstration purposes, build arguments to executable() by hand
-executable('mandelbrot', 'src/main.rs',
-  rust_dependency_map : pkg.rust_dependency_map(),
-  rust_args: pkg.rust_args(),
-  dependencies : pkg.dependencies(),
-  install : true,
-)
+# the above line is mostly short for
+#
+#   pkg = cargo.package()
+#   executable('mandelbrot', 'src/main.rs',
+#     rust_dependency_map : pkg.rust_dependency_map(),
+#     rust_args: pkg.rust_args(),
+#     dependencies : pkg.dependencies(),
+#     install : true,
+#   )
+#
+# and also picks rust_std from the package.edition key.  It's possible that
+# in the future more code generation options will be handled via [profile].


### PR DESCRIPTION
The next step in the Cargo workspace saga is to allow using the `cargo` object not just to trigger and retrieve dependencies for Cargo subprojects, but also to drive compilation of the toplevel itself.

mesonbuild/meson#15223 moves most of the logic to build command line arguments from the Cargo interpreter to methods in the workspace object, and this PR makes it possible to use the same logic in mandelbrot's `meson.build`. This greatly simplifies it, because all the information (dependencies, dependency map, lint arguments, etc.) is placed in `Cargo.toml` instead of `meson.build`.

That said, since finally there is _something_ that works in upstream Meson, this probably should only be merged after the corresponding PR.